### PR TITLE
Fix broken ModelShowcase link

### DIFF
--- a/src/components/ModelShowcase.tsx
+++ b/src/components/ModelShowcase.tsx
@@ -42,7 +42,7 @@ const ModelShowcase = () => {
           )}
         </div>
         <div className="text-center">
-          <Link to="/services/Modeller3D">
+          <Link to="/tjanster/3d-modeller">
             <Button 
               variant="outline" 
               size="lg" 


### PR DESCRIPTION
## Summary
- fix routing link for 3D model page

## Testing
- `npm run lint` *(fails: `no-empty-object-type` errors)*
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_684096f1d548832aaa8b1c6523ab5bde